### PR TITLE
Report status in slack

### DIFF
--- a/openshift_ci_job_trigger/libs/job_triggering.py
+++ b/openshift_ci_job_trigger/libs/job_triggering.py
@@ -49,7 +49,9 @@ class JobTriggering:
 
     def execute_trigger(self, job_db_path=None):
         slack_msg = f"""
-Job: {self.job_name} | Build ID: {self.build_id} | Prow ID: {self.prow_job_id}
+Job: {self.job_name}
+Build ID: {self.build_id}
+Prow ID: {self.prow_job_id}
 """
         with DB(job_db_path=job_db_path) as database:
             if database.check_prow_job_id_in_db(job_name=self.job_name, prow_job_id=self.prow_job_id):

--- a/openshift_ci_job_trigger/utils/general.py
+++ b/openshift_ci_job_trigger/utils/general.py
@@ -8,6 +8,6 @@ def send_slack_message(message, webhook_url, log_prefix, app_logger):
     app_logger.info(f"{log_prefix} Sending message to slack: {message}")
     response = requests.post(webhook_url, data=json.dumps(slack_data), headers={"Content-Type": "application/json"})
     if response.status_code != 200:
-        raise ValueError(
-            f"Request to slack returned an error {response.status_code} with the following message: " f"{response.text}"
+        app_logger.error(
+            f"Request to slack returned an error {response.status_code} with the following message: {response.text}"
         )

--- a/openshift_ci_job_trigger/utils/general.py
+++ b/openshift_ci_job_trigger/utils/general.py
@@ -1,0 +1,13 @@
+import json
+
+import requests
+
+
+def send_slack_message(message, webhook_url, log_prefix, app_logger):
+    slack_data = {"text": message}
+    app_logger.info(f"{log_prefix} Sending message to slack: {message}")
+    response = requests.post(webhook_url, data=json.dumps(slack_data), headers={"Content-Type": "application/json"})
+    if response.status_code != 200:
+        raise ValueError(
+            f"Request to slack returned an error {response.status_code} with the following message: " f"{response.text}"
+        )


### PR DESCRIPTION
Repost on slack for success/fail and already triggered statuses.

Required to pass `slack_webhook_url` to the webhook.

